### PR TITLE
Fix handling of clients initially unable to connect to server.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ RedisPool.prototype._createClient = function(_cb) {
       rc.removeListener('error', onError);
 
       if (err) {
-        RP.close(rc);
+        RP.close(rc, true); // force close (can't send QUIT if not connected)
         _cb(err);
         return;
       }
@@ -88,11 +88,16 @@ RedisPool.prototype._createClient = function(_cb) {
   rc.once('error', onError);
 };
 
-RedisPool.prototype.close = function(rc) {
+RedisPool.prototype.close = function(rc, force) {
   helpers.removeArrayEl(this._connections.free, rc);
   helpers.removeArrayEl(this._connections.all, rc);
   this._connections.count--;
-  rc.quit();
+
+  if (force)
+    rc.end();
+  else
+    rc.quit();
+
   this._releaseQueue();
 };
 


### PR DESCRIPTION
If `createClient()` can't connect to the redis server, it retries on a loop.  It also (by default) queues up commands in an offline queue, to be sent when connected.

On error connecting, this module was sending a `QUIT` command by calling `.quit()` on the node-redis client.  All this did was queue up the command in the offline queue - which evidently makes no sense at all.  This also resulted in an uncaught exception, which crashed our app, because there was no longer a listener on the client's 'error' event.

Instead, if we can't connect initially, we actually, genuinely kill the connection by calling `.end()` on the node-redis client.

Subsequent errors (after calling the pool-redis `getClient` callback) will be emitted and should be handled by apps.
